### PR TITLE
fix: "dbl.oisd.nl" to "big.oisd.nl" updated.

### DIFF
--- a/adlists.list.updater
+++ b/adlists.list.updater
@@ -29,4 +29,4 @@ https://urlhaus.abuse.ch/downloads/hostfile/
 # osint.digitalside.it malicious domains + malware
 https://osint.digitalside.it/Threat-Intel/lists/latestdomains.txt
 # Ads, Mobile Ads, Phishing, Malvertising, Malware, Spyware, Ransomware, CryptoJacking and some Telemetry, Analytics, Tracking
-https://dbl.oisd.nl/
+https://big.oisd.nl/


### PR DESCRIPTION
- Pi-hole: requires FTL v5.22, Web v5.19 and Core v5.16.1 (or Newer) to work.
Also, if you are still using `https://dbl.oisd.nl/`, please update to `https://big.oisd.nl`

Source: https://oisd.nl/