### PR TITLE
fix: updater error - expected 12 columns but found 10

### DIFF
--- a/adlists-updater.sh
+++ b/adlists-updater.sh
@@ -70,7 +70,7 @@ if [ -e "${adListFile}" ]; then
     # Only add non-empty lines
     if [[ -n "${domain}" ]]; then
       # Adlist table format
-      echo "${rowid},\"${domain}\",1,${timestamp},${timestamp},\"Added by Updater\",,0,0,0" >> "${tmpFile}"
+      echo "${rowid},\"${domain}\",1,${timestamp},${timestamp},\"Added by Updater\",${timestamp},0,0,0,0,0" >> "${tmpFile}"
       rowid=$((rowid+1))
     fi
   done


### PR DESCRIPTION
Fix for Issue #16 - adlists-updater.sh not updating adlist - gravity.db has new fields